### PR TITLE
Update the default maximum message size sent by Ice to 256MB

### DIFF
--- a/omero/sysadmins/grid.rst
+++ b/omero/sysadmins/grid.rst
@@ -398,7 +398,7 @@ which passes the inputs all the way down to :file:`processor.py` will need
 to have a sufficiently large ``Ice.MessageSizeMax`` for: the client, the
 Glacier2 router, the :doc:`/developers/server-blitz` server, and the Processor.
 
-The default is currently set to 65536 kilobytes which is 64MB.
+The default is currently set to 256MB (250000KiB).
 
 Logging
 ^^^^^^^


### PR DESCRIPTION
The previous default value was increased in OMERO.server 5.2.2 but this change never propagated to the documentation - see https://github.com/ome/openmicroscopy/pull/4428

Note the original PR indicates 250MB but the error message suggest 256000000 bytes - see https://forum.image.sc/t/ice-messagesizemax-error-during-import-of-large-plate/116703, https://github.com/ome/omero-cli-zarr/issues/111 or https://www.openmicroscopy.org/community/viewtopic.php?p=20837

Although the [Ice 3.6 documentation](https://archive.zeroc.com/ice/3.6/property-reference/miscellaneous-ice-properties#id-.MiscellaneousIce.*Propertiesv3.6-Ice.MessageSizeMax) states this value is in kilobytes, the statement `The default size is 1024 (1 megabyte).` suggests it should be interpreted as KiB instead. This makes it consistent with the value sent in templates and the error message above as 2500000KiB = 2500000 * 1024 B = 256000000B