### PR TITLE
Deprecate homebrew and remove link

### DIFF
--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -1,6 +1,13 @@
 OMERO.server installation on OS X with Homebrew
 ===============================================
 
+
+.. note::
+   :title: Deprecated workflow
+
+   This workflow is deprecated and not tested regularly. Also, it does not work on Apple Silicon Macs. If you need a local OMERO.server for development, use the official `Docker image <https://github.com/ome/omero-server-docker>`_, possibly in `docker-compose setup <https://github.com/ome/docker-example-omero/blob/master/DEV_README.md>`.
+
+
 .. topic:: Overview
 
     This walkthrough demonstrates how to install OMERO on a clean Mac
@@ -427,9 +434,6 @@ to reinitialize a PostgreSQL database cluster as::
 
     $ rm -rf /usr/local/var/postgres
     $ initdb -E UTF8 /usr/local/var/postgres
-
-.. seealso::
-  https://stackoverflow.com/questions/25970132/pg-tblspc-missing-after-installation-of-latest-version-of-os-x-yosemite-or-el
 
 szip
 ^^^^

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -4,7 +4,7 @@ OMERO.server installation on OS X with Homebrew
 
 .. note:: Deprecated workflow
 
-   This workflow is deprecated and not regularly tested. It does not
+   This workflow is deprecated and no longer tested. It does not
    work on Apple Silicon Macs (M1, M2, etc.). For a local OMERO.server
    development environment, use the official `Docker image
    <https://github.com/ome/omero-server-docker>`_, possibly with the

--- a/omero/sysadmins/unix/server-install-homebrew.rst
+++ b/omero/sysadmins/unix/server-install-homebrew.rst
@@ -2,10 +2,14 @@ OMERO.server installation on OS X with Homebrew
 ===============================================
 
 
-.. note::
-   :title: Deprecated workflow
+.. note:: Deprecated workflow
 
-   This workflow is deprecated and not tested regularly. Also, it does not work on Apple Silicon Macs. If you need a local OMERO.server for development, use the official `Docker image <https://github.com/ome/omero-server-docker>`_, possibly in `docker-compose setup <https://github.com/ome/docker-example-omero/blob/master/DEV_README.md>`.
+   This workflow is deprecated and not regularly tested. It does not
+   work on Apple Silicon Macs (M1, M2, etc.). For a local OMERO.server
+   development environment, use the official `Docker image
+   <https://github.com/ome/omero-server-docker>`_, possibly with the
+   `docker-compose setup
+   <https://github.com/ome/docker-example-omero/blob/master/DEV_README.md>`_.
 
 
 .. topic:: Overview

--- a/omero/sysadmins/unix/server-installation.rst
+++ b/omero/sysadmins/unix/server-installation.rst
@@ -30,13 +30,6 @@ Since 5.6, a new :envvar:`OMERODIR` variable is used, you should first unset :en
   Instructions for installing OMERO.server from scratch on
   Ubuntu 22.04 with Ice 3.6 and Python 3.10.
 
-**Development:**
-
-:doc:`server-install-homebrew`
-  Instructions for installing and building OMERO.server on Mac
-  OS X with dependencies installed using Homebrew. It is aimed at **developers**
-  since typically MacOS X is not suited for serious server deployment.
-
 .. toctree::
     :maxdepth: 1
     :titlesonly:


### PR DESCRIPTION
This PR:

- Adds a deprecation note with helpful link to docker images for development on Mac OS
- Removes the outdated and failing (html proofer) stackoverflow link

<img width="742" height="313" alt="Screenshot 2026-08-18 at 12 10 02" src="https://github.com/user-attachments/assets/fdca05c8-2bcb-4c44-80dc-c00f6e1de584" />


Built at https://omero--2546.org.readthedocs.build/en/2546/sysadmins/unix/server-install-homebrew.html

cc @sbesson @jburel 